### PR TITLE
Manually pin to numpy 1.9 for building

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -10,8 +10,6 @@ docker_image:
 - condaforge/linux-anvil-comp7
 gsl:
 - '2.4'
-numpy:
-- '1.14'
 pin_run_as_build:
   gsl:
     max_pin: x.x

--- a/.ci_support/osx_.yaml
+++ b/.ci_support/osx_.yaml
@@ -14,8 +14,6 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
-numpy:
-- '1.14'
 pin_run_as_build:
   gsl:
     max_pin: x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:
@@ -61,7 +61,7 @@ outputs:
         - {{ pin_subpackage('lalpulsar', exact=True) }}
         - libblas=*=*netlib
         # numpy pin is proscribed by astropy for py37
-        - numpy  # [py!=37]
+        - numpy 1.9  # [py!=37]
         - numpy 1.11.3  # [py>=37]
         - python
         - python-lal >={{ lal_version }}


### PR DESCRIPTION
so that we can use any version after that at run time
see conda-forge/conda-forge-pinning-feedstock#228

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
