### PR TITLE
Explicitly pin builds against fftw nompi

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 3
+  number: 4
   skip: true  # [win]
 
 requirements:
@@ -26,7 +26,7 @@ requirements:
     - swig >={{ swig_version }}
   host:
     - cfitsio
-    - fftw
+    - fftw * nompi*  # [fft_impl == "fftw"]
     - gsl
     - lal >={{ lal_version }} fftw*
     - libblas * *netlib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - swig >={{ swig_version }}
   host:
     - cfitsio
-    - fftw * nompi*  # [fft_impl == "fftw"]
+    - fftw * nompi*
     - gsl
     - lal >={{ lal_version }} fftw*
     - libblas * *netlib


### PR DESCRIPTION
...which allows any version to be used at runtime

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
