### PR TITLE
Added activate/deactivate scripts

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -25,6 +25,7 @@ jobs:
 
   - script: |
         export CI=azure
+        export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
         .azure-pipelines/run_docker_build.sh
     displayName: Run docker build
     env:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -68,8 +68,9 @@ jobs:
 
   - script: |
       source activate base
+      export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
       upload_package ./ ./recipe ./.ci_support/${CONFIG}.yaml
-    displayName: Upload recipe
+    displayName: Upload package
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
     condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))

--- a/.azure-pipelines/run_docker_build.sh
+++ b/.azure-pipelines/run_docker_build.sh
@@ -64,6 +64,8 @@ docker run ${DOCKER_RUN_ARGS} \
            -e BINSTAR_TOKEN \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \
+           -e GIT_BRANCH \
+           -e UPLOAD_ON_BRANCH \
            -e CI \
            $DOCKER_IMAGE \
            bash \

--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -12,6 +12,8 @@ docker_image:
 - condaforge/linux-anvil-comp7
 gsl:
 - '2.5'
+libblas:
+- 3.8 *netlib
 numpy:
 - '1.14'
 pin_run_as_build:

--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -12,8 +12,6 @@ docker_image:
 - condaforge/linux-anvil-comp7
 gsl:
 - '2.5'
-libblas:
-- 3.8 *netlib
 numpy:
 - '1.14'
 pin_run_as_build:

--- a/.ci_support/osx_.yaml
+++ b/.ci_support/osx_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '4'
+- '9'
 cfitsio:
 - '3.470'
 channel_sources:

--- a/.ci_support/osx_.yaml
+++ b/.ci_support/osx_.yaml
@@ -12,8 +12,6 @@ channel_targets:
 - conda-forge main
 gsl:
 - '2.5'
-libblas:
-- 3.8 *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/.ci_support/osx_.yaml
+++ b/.ci_support/osx_.yaml
@@ -12,6 +12,8 @@ channel_targets:
 - conda-forge main
 gsl:
 - '2.5'
+libblas:
+- 3.8 *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,18 @@
 meta.yaml text eol=lf
 build.sh text eol=lf
 bld.bat text eol=crlf
+
+# github helper pieces to make some files not show up in diffs automatically
+.azure-pipelines/* linguist-generated=true
+.circleci/* linguist-generated=true
+.github/* linguist-generated=true
+.travis/* linguist-generated=true
+.appveyor.yml linguist-generated=true
+.gitattributes linguist-generated=true
+.gitignore linguist-generated=true
+.travis.yml linguist-generated=true
+LICENSE.txt linguist-generated=true
+README.md linguist-generated=true
+azure-pipelines.yml linguist-generated=true
+build-locally.py linguist-generated=true
+shippable.yml linguist-generated=true

--- a/README.md
+++ b/README.md
@@ -59,7 +59,12 @@ Current build status
       <img src="https://img.shields.io/badge/Windows-disabled-lightgrey.svg" alt="Windows disabled">
     </td>
   </tr>
-![ppc64le disabled](https://img.shields.io/badge/ppc64le-disabled-lightgrey.svg)
+  <tr>
+    <td>Linux_ppc64le</td>
+    <td>
+      <img src="https://img.shields.io/badge/ppc64le-disabled-lightgrey.svg" alt="ppc64le disabled">
+    </td>
+  </tr>
 </table>
 
 Current release info

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,6 +6,7 @@ set -e
 export GSL_LIBS="-L${PREFIX}/lib -lgsl"
 export CFITSIO_LIBS="-L${PREFIX}/lib -lcfitsio"
 
+# configure
 ./configure \
 	--prefix="${PREFIX}" \
 	--enable-swig-iface \
@@ -15,6 +16,36 @@ export CFITSIO_LIBS="-L${PREFIX}/lib -lcfitsio"
 	--disable-gcc-flags \
 	--enable-silent-rules \
 	--enable-cfitsio
+
+# build
 make -j ${CPU_COUNT}
+
+# check
 make -j ${CPU_COUNT} check
+
+# install
 make install
+
+# -- create activate/deactivate scripts
+PKG_NAME_UPPER=$(echo ${PKG_NAME} | awk '{ print toupper($0) }')
+
+# activate.sh
+ACTIVATE_SH="${PREFIX}/etc/conda/activate.d/activate_${PKG_NAME}.sh"
+mkdir -p $(dirname ${ACTIVATE_SH})
+cat > ${ACTIVATE_SH} << EOF
+#!/bin/bash
+export CONDA_BACKUP_${PKG_NAME_UPPER}_DATADIR="\${${PKG_NAME_UPPER}_DATADIR:-empty}"
+export ${PKG_NAME_UPPER}_DATADIR="/opt/anaconda1anaconda2anaconda3/share/${PKG_NAME}"
+EOF
+# deactivate.sh
+DEACTIVATE_SH="${PREFIX}/etc/conda/deactivate.d/deactivate_${PKG_NAME}.sh"
+mkdir -p $(dirname ${DEACTIVATE_SH})
+cat > ${DEACTIVATE_SH} << EOF
+#!/bin/bash
+if [ "\${CONDA_BACKUP_${PKG_NAME_UPPER}_DATADIR}" == "empty" ]; then
+>---unset ${PKG_NAME_UPPER}_DATADIR
+else
+>---export ${PKG_NAME_UPPER}_DATADIR="\${CONDA_BACKUP_${PKG_NAME_UPPER}_DATADIR}"
+fi
+unset CONDA_BACKUP_${PKG_NAME_UPPER}_DATADIR
+EOF

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
+  error_overdepending: true
   error_overlinking: true
   ignore_run_exports:
     # run_exports parsing for fftw is broken, so we ignore it

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,6 +70,8 @@ outputs:
         - python-lal >={{ lal_version }}
       run:
         - astropy
+        - cfitsio  # [linux]
+        - fftw  # [linux]
         - gsl
         - lal >={{ lal_version }}
         - {{ pin_subpackage('lalpulsar', exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,6 @@ requirements:
     - fftw * nompi*
     - gsl
     - lal >={{ lal_version }} fftw*
-    - libblas
   run:
     - cfitsio
     - fftw

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - fftw * nompi*
     - gsl
     - lal >={{ lal_version }} fftw*
-    - libblas * *netlib
+    - libblas
   run:
     - cfitsio
     - fftw
@@ -66,7 +66,6 @@ outputs:
         - gsl
         - lal >={{ lal_version }}
         - {{ pin_subpackage('lalpulsar', exact=True) }}
-        - libblas=*=*netlib
         - numpy
         - python
         - python-lal >={{ lal_version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,12 +15,13 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
-  skip: true  # [win]
+  error_overlinking: true
   ignore_run_exports:
     # run_exports parsing for fftw is broken, so we ignore it
     # manually, for now
     - fftw
+  number: 1
+  skip: true  # [win]
 
 requirements:
   build:
@@ -42,6 +43,7 @@ requirements:
 
 test:
   commands:
+    - test ${LALPULSAR_DATADIR} == "${PREFIX}/share/lalpulsar"  # [unix]
     - lalpulsar_version --verbose
 
 outputs:


### PR DESCRIPTION
This PR adds a (de)activate scripts to (un)set the `LALPULSAR_DATADIR` environment variable. This is basically the only useful part of `lalpulsar-user-env.sh` when working in a conda environment.

cc @skymoo

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
