### PR TITLE
Fix activate script in liblalpulsar

### DIFF
--- a/recipe/install-lib.sh
+++ b/recipe/install-lib.sh
@@ -15,25 +15,23 @@ make -j ${CPU_COUNT} V=1 VERBOSE=1 install-pkgconfigDATA
 
 # -- create activate/deactivate scripts
 
-PKG_NAME_UPPER=$(echo ${PKG_NAME} | awk '{ print toupper($0) }')
-
 # activate.sh
-ACTIVATE_SH="${PREFIX}/etc/conda/activate.d/activate_${PKG_NAME}.sh"
+ACTIVATE_SH="${PREFIX}/etc/conda/activate.d/activate_lalpulsar.sh"
 mkdir -p $(dirname ${ACTIVATE_SH})
 cat > ${ACTIVATE_SH} << EOF
 #!/bin/bash
-export CONDA_BACKUP_${PKG_NAME_UPPER}_DATADIR="\${${PKG_NAME_UPPER}_DATADIR:-empty}"
-export ${PKG_NAME_UPPER}_DATADIR="/opt/anaconda1anaconda2anaconda3/share/${PKG_NAME}"
+export CONDA_BACKUP_LALPULSAR_DATADIR="\${LALPULSAR_DATADIR:-empty}"
+export LALPULSAR_DATADIR="/opt/anaconda1anaconda2anaconda3/share/lalpulsar"
 EOF
 # deactivate.sh
-DEACTIVATE_SH="${PREFIX}/etc/conda/deactivate.d/deactivate_${PKG_NAME}.sh"
+DEACTIVATE_SH="${PREFIX}/etc/conda/deactivate.d/deactivate_lalpulsar.sh"
 mkdir -p $(dirname ${DEACTIVATE_SH})
 cat > ${DEACTIVATE_SH} << EOF
 #!/bin/bash
-if [ "\${CONDA_BACKUP_${PKG_NAME_UPPER}_DATADIR}" = "empty" ]; then
-	unset ${PKG_NAME_UPPER}_DATADIR
+if [ "\${CONDA_BACKUP_LALPULSAR_DATADIR}" = "empty" ]; then
+	unset LALPULSAR_DATADIR
 else
-	export ${PKG_NAME_UPPER}_DATADIR="\${CONDA_BACKUP_${PKG_NAME_UPPER}_DATADIR}"
+	export LALPULSAR_DATADIR="\${CONDA_BACKUP_LALPULSAR_DATADIR}"
 fi
-unset CONDA_BACKUP_${PKG_NAME_UPPER}_DATADIR
+unset CONDA_BACKUP_LALPULSAR_DATADIR
 EOF

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
 build:
   error_overdepending: true
   error_overlinking: true
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -99,6 +99,8 @@ outputs:
         - python
         - python-lal >={{ lal_version }}
         - six
+        # swig bindings cause segmentation fault
+        - numpy <1.20.0a0
     test:
       requires:
         - pytest >=4.0.0a0


### PR DESCRIPTION
The activate script was originally written to go in a package named `lalpulsar` so when the logic to write it was moved into `liblalpulsar`, things got screwed up.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
