### PR TITLE
Fix install name for deactivate scripts

### DIFF
--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 cfitsio:
 - 4.1.0
 channel_sources:
@@ -15,7 +15,7 @@ fftw:
 gsl:
 - '2.7'
 llvm_openmp:
-- '12'
+- '13'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 cfitsio:
 - 4.1.0
 channel_sources:
@@ -15,7 +15,7 @@ fftw:
 gsl:
 - '2.7'
 llvm_openmp:
-- '12'
+- '13'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,8 @@ version: 2
 jobs:
   build:
     working_directory: ~/test
-    machine: true
+    machine:
+      image: ubuntu-2004:current
     steps:
       - run:
           # The Circle-CI build should not be active, but if this is not true for some reason, do a fast finish.

--- a/README.md
+++ b/README.md
@@ -84,16 +84,41 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `lalpulsar, lalpulsar-data, liblalpulsar, python-lalpulsar` can be installed with:
+Once the `conda-forge` channel has been enabled, `lalpulsar, lalpulsar-data, liblalpulsar, python-lalpulsar` can be installed with `conda`:
 
 ```
 conda install lalpulsar lalpulsar-data liblalpulsar python-lalpulsar
 ```
 
-It is possible to list all of the versions of `lalpulsar` available on your platform with:
+or with `mamba`:
+
+```
+mamba install lalpulsar lalpulsar-data liblalpulsar python-lalpulsar
+```
+
+It is possible to list all of the versions of `lalpulsar` available on your platform with `conda`:
 
 ```
 conda search lalpulsar --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search lalpulsar --channel conda-forge
+```
+
+Alternatively, `mamba repoquery` may provide more information:
+
+```
+# Search all versions available on your platform:
+mamba repoquery search lalpulsar --channel conda-forge
+
+# List packages depending on `lalpulsar`:
+mamba repoquery whoneeds lalpulsar --channel conda-forge
+
+# List dependencies of `lalpulsar`:
+mamba repoquery depends lalpulsar --channel conda-forge
 ```
 
 
@@ -111,10 +136,12 @@ for each of the installable packages. Such a repository is known as a *feedstock
 A feedstock is made up of a conda recipe (the instructions on what and how to build
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
-[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
-packages to the [conda-forge](https://anaconda.org/conda-forge)
-[Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
+[Azure](https://azure.microsoft.com/en-us/services/devops/), [GitHub](https://github.com/),
+[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/),
+[Drone](https://cloud.drone.io/welcome), and [TravisCI](https://travis-ci.com/)
+it is possible to build and upload installable packages to the
+[conda-forge](https://anaconda.org/conda-forge) [Anaconda-Cloud](https://anaconda.org/)
+channel for Linux, Windows and OSX respectively.
 
 To manage the continuous integration and simplify feedstock maintenance
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.

--- a/recipe/install-data.sh
+++ b/recipe/install-data.sh
@@ -11,7 +11,7 @@ make -j ${CPU_COUNT} V=1 VERBOSE=1 -C lib install-pkgdataDATA
 for action in activate deactivate; do
 	mkdir -p ${PREFIX}/etc/conda/${action}.d
 	for ext in sh csh; do
-		_target="${PREFIX}/etc/conda/${action}.d/activate-${PKG_NAME}.${ext}"
+		_target="${PREFIX}/etc/conda/${action}.d/${action}-${PKG_NAME}.${ext}"
 		echo "-- Installing: ${_target}"
 		cp "${RECIPE_DIR}/${action}-${PKG_NAME}.${ext}" "${_target}"
 	done

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
 build:
   error_overdepending: true
   error_overlinking: true
-  number: 1
+  number: 2
   skip: true  # [win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -127,7 +127,7 @@ outputs:
       error_overdepending: true
       error_overlinking: true
       ignore_run_exports:
-        # ignore run_exports from python's recipe
+        - numpy
         - python
     requirements:
       build:


### PR DESCRIPTION
This PR fixes #43 by correcting the installed name for the deactivate scripts.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
